### PR TITLE
Helios now automatically creates SSL certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A minimalistic CMS using Node.js and React.
 
 We use Bulma as CSS Framework, next.js for Server Side Rendering and Slate as Content Editor.
 
+Live Demo: [https://helios.patrick-sachs.de/](https://helios.patrick-sachs.de/)
+
 ## Why?
 
 There are tons of CMS out there. Wordpress dwarfs the market with tons of extensions and great support. So why another one?
@@ -15,16 +17,17 @@ There are two very simple reasons why I wrote Helios:
 
 Why should you **use** Helios?
 
-- Helios was developed with a mobile first approach.
-- Helios is lightweight - Low resource usage on the server, fast load speeds for your visitors due to Server Side Rendering & Gzip compression.
-- Helios is easily forkable - Getting into the codebase and changing things to your liking isn't difficult.
-- Helios is MIT licensed - You can do WHATEVER you want with it.
-- Helios is secure, traffic is served over HTTPS(preferably HTTP/2) only.
+- Helios was developed with a **mobile first** approach.
+- Helios is lightweight - Low resource usage on the server, **fast load speeds** for your visitors due to Server Side Rendering & Compression.
+- Helios is **easily forkable** - Getting into the codebase and changing things to your liking isn't difficult.
+- Helios is **MIT licensed** - You can do WHATEVER you want with it.
+- Helios is secure, traffic is served over HTTPS(preferably HTTP/2) only(It doesn't even require you to know anything about SSL. It's **automatically encrypted** with a valid certificate!).
 
 Why should you **not use** Helios?
 
 - Helios does not offer a plugin system.
 - Helios is mainly aimed at developers. If you want to customize something, you are required to touch a code file.
+- Helios doesn't like to run outside of server environments. It does run, but requires you to have some knowledge about SSL.
 
 ## Develop
 
@@ -41,9 +44,7 @@ $ npm run dev
 
 ## Compile/Deploy
 
-**Important**: Make sure to adjust the config files(`/src/config`). These contain your private keys. If you leave them at their default values, it will be rather trivial to decrypt your senstive user data you are bound by law to protect.
-
-**Warning**: Untested & Unsupported, currently still early in development
+**Important**: Make sure to adjust the config files(`/src/config`). These contain your private keys for passwords. If you leave them at their default values, it will be rather trivial to decrypt your senstive user data you are bound by law to protect.
 
 ```
 $ npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -841,6 +841,233 @@
         "negotiator": "0.6.1"
       }
     },
+    "acme": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/acme/-/acme-1.0.12.tgz",
+      "integrity": "sha512-qQ6iVnyKWE2ux+lRQ7dZebKARX86hLFCDg1vxAWePBKWuknoiHafX2gOfT3+6BcJ6vwly1SeZaFQsln4+iQKTg==",
+      "requires": {
+        "acme-v2": "^1.0.7",
+        "bluebird": "^3.5.1",
+        "request": "^2.85.0",
+        "rsa-compat": "^1.3.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "optional": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        }
+      }
+    },
+    "acme-v2": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/acme-v2/-/acme-v2-1.0.8.tgz",
+      "integrity": "sha512-Cht6XT6BNWKMFKswPh6CjLT+6cn9OukNiUTaE01pfNv5I49dqVw2Mx5ugWAeUTVxMg0g7smMy7AOnZ9sJxtCtw==",
+      "requires": {
+        "bluebird": "^3.5.1",
+        "request": "^2.85.0",
+        "rsa-compat": "^1.3.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "optional": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        }
+      }
+    },
     "acorn": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
@@ -1285,6 +1512,11 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "asn1js": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-1.2.12.tgz",
+      "integrity": "sha1-h9XueXWWri0qPLAkciDcQv/D8hE="
+    },
     "assert": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
@@ -1652,6 +1884,12 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
     },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "optional": true
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -1822,6 +2060,11 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
       "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
     },
+    "buffer-v6-polyfill": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/buffer-v6-polyfill/-/buffer-v6-polyfill-1.0.5.tgz",
+      "integrity": "sha1-0c2v61YAvvbCjWFElkJWvRLgFnc="
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -1967,6 +2210,17 @@
       "requires": {
         "align-text": "^0.1.3",
         "lazy-cache": "^1.0.3"
+      }
+    },
+    "certpem": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/certpem/-/certpem-1.0.1.tgz",
+      "integrity": "sha1-+koljEBXllxGVwCCL7jYB9fy2fU=",
+      "requires": {
+        "asn1js": "^1.2.12",
+        "buffer-v6-polyfill": "^1.0.3",
+        "node.extend": "^1.1.5",
+        "pkijs": "^1.3.27"
       }
     },
     "chalk": {
@@ -3516,6 +3770,16 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-symlink": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fs-symlink/-/fs-symlink-1.2.1.tgz",
+      "integrity": "sha1-G+uoPqncqBI2AOPwuaUbGGQLvEA=",
+      "requires": {
+        "mkdirp": "^0.5.0",
+        "mkdirp-then": "1",
+        "mz": "^2.0.0"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -4184,10 +4448,55 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "greenlock": {
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/greenlock/-/greenlock-2.2.19.tgz",
+      "integrity": "sha512-tdD5iwgB3SCtmtKNf1Wx/tKJP/nDOhE7Au4M6nfyEu/iUr0tQpWLA951g5msbAPeVKGq0G6FQUOulKUSCbiFhA==",
+      "requires": {
+        "acme": "^1.0.6",
+        "acme-v2": "^1.0.6",
+        "asn1js": "^1.2.12",
+        "bluebird": "^3.5.1",
+        "certpem": "^1.0.0",
+        "le-acme-core": "^2.1.3",
+        "le-challenge-fs": "^2.0.2",
+        "le-sni-auto": "^2.1.3",
+        "le-store-certbot": "^2.1.0",
+        "node.extend": "^1.1.5",
+        "pkijs": "^1.3.27",
+        "rsa-compat": "^1.3.2"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "optional": true
+        }
+      }
+    },
+    "greenlock-express": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/greenlock-express/-/greenlock-express-2.1.6.tgz",
+      "integrity": "sha512-f8KQ4HNADclrn36SrSxlPDXVIdJa7J9bJguhQ357DJSIKu4aXPYVczQfZQpOSKP6g+KUAgCjKeBXhIuymyGIwg==",
+      "requires": {
+        "greenlock": "^2.2.16",
+        "le-challenge-fs": "^2.0.8",
+        "le-sni-auto": "^2.1.4",
+        "le-store-certbot": "^2.1.0",
+        "redirect-https": "^1.1.5",
+        "spdy": "^3.4.7"
+      }
+    },
     "handle-thing": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "2.0.6",
@@ -4549,6 +4858,11 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
       "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+    },
+    "is": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+      "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU="
     },
     "is-absolute-url": {
       "version": "2.1.0",
@@ -4959,6 +5273,58 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
         "invert-kv": "^1.0.0"
+      }
+    },
+    "le-acme-core": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/le-acme-core/-/le-acme-core-2.1.3.tgz",
+      "integrity": "sha512-GFl4rfhn8XIrw5dJDJe/xcGcTkYrluc3kcxIhpa6TXrkOlOCrYlv+s1wqoDM6cn2ainxg+PM/6F/XXMxnn9WTQ==",
+      "optional": true,
+      "requires": {
+        "request": "^2.74.0",
+        "rsa-compat": "^1.3.2"
+      }
+    },
+    "le-challenge-fs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/le-challenge-fs/-/le-challenge-fs-2.0.8.tgz",
+      "integrity": "sha1-ttRYo38JfoffPYtf9nATc3q51aI=",
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "le-sni-auto": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/le-sni-auto/-/le-sni-auto-2.1.5.tgz",
+      "integrity": "sha512-AUlFpYifutAAs0D0UwVVD5Jzf+X2J6+VNb03LCOFVAezQNpNcQFsWwrZzd+y24gF7jYHGBbD25q8gURQ5rhL8w==",
+      "requires": {
+        "bluebird": "^3.5.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        }
+      }
+    },
+    "le-store-certbot": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/le-store-certbot/-/le-store-certbot-2.1.2.tgz",
+      "integrity": "sha512-WbSMNichHuUNxGss2/+cI/l+2ho+go5kcbx8WwKcq5jXEsh5eM70DA6vKn54iCNl+ob/bf2oHc496wyZbyVkgA==",
+      "requires": {
+        "bluebird": "^3.5.1",
+        "fs-symlink": "^1.2.1",
+        "mkdirp": "^0.5.1",
+        "pyconf": "^1.1.2",
+        "safe-replace": "^1.0.2"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        }
       }
     },
     "load-json-file": {
@@ -5510,6 +5876,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
@@ -5720,6 +6096,11 @@
         "is-stream": "^1.0.1"
       }
     },
+    "node-forge": {
+      "version": "0.6.49",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.49.tgz",
+      "integrity": "sha1-8e6V1ddGI5OP4Z1piqWibVTS9g8="
+    },
     "node-gyp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
@@ -5854,6 +6235,14 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
+      }
+    },
+    "node.extend": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+      "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+      "requires": {
+        "is": "^3.1.0"
       }
     },
     "nopt": {
@@ -6227,6 +6616,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -6260,6 +6654,11 @@
       "requires": {
         "find-up": "^2.1.0"
       }
+    },
+    "pkijs": {
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-1.3.33.tgz",
+      "integrity": "sha1-ponvYhE7fDSOH/wJll0iOeW7TJI="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -6928,6 +7327,14 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "pyconf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pyconf/-/pyconf-1.1.5.tgz",
+      "integrity": "sha512-zXEg0oUJ4mY6azqVvRy6rePTIHZGhDQG3z9PVkE60uUabS9uILiIkHobU2Jzcs3tBltMBqyEATZZezRR/UFjkg==",
+      "requires": {
+        "safe-replace": "^1.0.2"
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -7249,6 +7656,14 @@
         "strip-indent": "^1.0.1"
       }
     },
+    "redirect-https": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/redirect-https/-/redirect-https-1.1.5.tgz",
+      "integrity": "sha512-40okBDSPOoK3E8ttlKxG60vBJMmxT+UPS43zrIkWo6QlNrRgvj/jY/trvATXpCN4XpuySdYsQnXxgfB8QBsBHg==",
+      "requires": {
+        "escape-html": "^1.0.3"
+      }
+    },
     "reduce-css-calc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
@@ -7513,6 +7928,16 @@
         "inherits": "^2.0.1"
       }
     },
+    "rsa-compat": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rsa-compat/-/rsa-compat-1.3.2.tgz",
+      "integrity": "sha512-sM72vHknKfnMefm3VZf4sWdCrWdTRec7pvhB3ALmsCWCuDELiToZJZ4CAzJgfyiWOhkXtG9z/1Lz9GEcCalHGQ==",
+      "requires": {
+        "buffer-v6-polyfill": "^1.0.3",
+        "node-forge": "^0.6.41",
+        "ursa": "^0.9.4"
+      }
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -7533,6 +7958,11 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safe-replace": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/safe-replace/-/safe-replace-1.0.2.tgz",
+      "integrity": "sha1-sYGrQJWs32qwqPhAUXSRyoqZIro="
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -8500,6 +8930,22 @@
         "inherits": "2"
       }
     },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
     "through2": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -8893,6 +9339,16 @@
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
+      }
+    },
+    "ursa": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/ursa/-/ursa-0.9.4.tgz",
+      "integrity": "sha1-Ciq/t9xCZ/czsPjy/H8siV1ApBM=",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.3.3"
       }
     },
     "use": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "express": "^4.16.3",
     "express-session": "^1.15.6",
     "glob": "^7.1.2",
+    "greenlock-express": "^2.1.6",
     "immutable": "^3.8.2",
     "mongoose": "^5.1.1",
     "next": "^6.0.3",

--- a/src/config/client.js
+++ b/src/config/client.js
@@ -1,5 +1,15 @@
 module.exports = {
+  // The title/name of your website
   title: "Helios",
+
+  // A short one-liner what your website is about.
   description: "A minimalistic CMS using Node.js and React.",
+
+  // Host on these domains. The first domain will be your primaty, canocial URL
+  // IPs are NOT ALLOWED if using { certs: "lets-encrypt" } (which is the default)
+  // in the server.js config!
+  domains: ["helios.patrick-sachs.de", "www.helios.patrick-sachs.de"],
+
+  // The max size in bytes for user avatars.
   maxAvatarSize: 200 * 1024
 }

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -9,6 +9,9 @@ module.exports = {
   // encrypted data is stored on the client.
   cookieSecret: "7-rays-of-light",
 
+  // The Webmaster mail. This MUST be valid Mail or you won't get a SSL certificate
+  webmasterMail: "sonstiges@patrick-sachs.de",
+
   // The default user to create. Will have admin permissions. Simply delete this 
   // entry or set it to false to avoid creating a default user.
   defaultUser: {
@@ -30,6 +33,12 @@ module.exports = {
   // The max size of data that can be sent in a single request.
   maxPayloadSize: client.maxAvatarSize + 100 * 1024,
 
+  // By default we let Let's Encrypt create a nice and free cert for us. If you are
+  // hosting on an intranet this is not possible though, so you may prefer the config
+  // below.
+  certs: "lets-encrypt",
+
+  /*
   // Paths to your SSL certificates. Make sure they are signed by a proper authority 
   // if used for a public server, or browsers will complain. (This typically isn't free)
   // The two certificates included by default are development certificates and not
@@ -37,10 +46,12 @@ module.exports = {
   certs: {
     // Are unsigned certs allowed in production? (NOT recommended)
     allowUnsigned: true,
+
     // Your keys. They are to be placed in this directory.
     key: path.resolve(__dirname, "./key.pem"),
     cert: path.resolve(__dirname, "./server.crt")
   },
+  */
 
   // The client configuration should also be available on the server.
   client

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,9 +1,11 @@
 const fs = require("fs");
 const axios = require("axios");
 const spdy = require("spdy");
+const path = require("path");
 const createNext = require("next");
 const express = require("express");
 const session = require("express-session");
+const greenlock = require("greenlock-express");
 const compression = require("compression");
 const api = require("./api");
 const db = require("./db");
@@ -12,16 +14,14 @@ const config = require("../config/server");
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 
-axios.defaults.baseURL = `https://localhost:${config.port.https}`;
+// We use the domain in the request and not localhost since our certificate is not signed against localhost, 
+// and we don't accept unsigned certs in production.
+axios.defaults.baseURL = `https://${config.client.domains[0]}:${config.port.https}`;
+
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = isDevelopment || config.certs.allowUnsigned ? "0" : "1";
 
 console.log("📡", "Helios is starting ...");
 console.log("📡", "Dev-Mode:", isDevelopment);
-
-const next = createNext({
-  dev: isDevelopment,
-  dir: "./src"
-});
 
 const $send = (res, { error, data, errorCode, successCode }) => {
   console.info("sending", { error, data, errorCode, successCode })
@@ -39,31 +39,67 @@ const $send = (res, { error, data, errorCode, successCode }) => {
 $send.missingPermission = (res, permission) => $send(res, { error: `missing-permission-${permission}`, errorCode: 403 });
 $send.incorrectPassword = (res) => $send(res, { error: "incorrect-password", errorCode: 400 });
 
-Promise.all([next.prepare(), db.connected]).then(([_, dbResolved]) => {
+// Creates the express server BUT DOES NOT LISTEN TO it that will be used to handle requests.
+const installServer = () => {
+  const next = createNext({
+    dev: isDevelopment,
+    dir: "./src"
+  });
   const server = express();
+  Promise.all([next.prepare(), db.connected]).then(([_, dbResolved]) => {
+    server.use(compression({ filter: shouldCompress }));
+    server.use(express.json({ limit: config.maxPayloadSize }));
+    server.use(express.urlencoded({ limit: config.maxPayloadSize, extended: true }));
+    server.use("/static", express.static("static"));
+    server.use(session({
+      // todo: Have a look at this again once we switch to HTTPS, or go live(Cookie laws...)!
+      // todo: Use a better session store! (MongoDB)
+      secret: config.cookieSecret
+    }));
 
-  server.use(compression({ filter: shouldCompress }));
-  server.use(express.json({ limit: config.maxPayloadSize }));
-  server.use(express.urlencoded({ limit: config.maxPayloadSize, extended: true }));
-  server.use("/static", express.static("static"));
-  server.use(session({
-    // todo: Have a look at this again once we switch to HTTPS, or go live(Cookie laws...)!
-    // todo: Use a better session store! (MongoDB)
-    secret: config.cookieSecret
-  }));
+    // Pages
+    server.get("/admin/post/:id", (req, res) => next.render(req, res, "/admin/post", req.params));
+    server.get("/post", (req, res) => next.render(req, res, "/", req.params));
+    server.get("/post/:id", (req, res) => next.render(req, res, "/post", req.params));
 
-  // Pages
-  server.get("/admin/post/:id", (req, res) => next.render(req, res, "/admin/post", req.params));
-  server.get("/post", (req, res) => next.render(req, res, "/", req.params));
-  server.get("/post/:id", (req, res) => next.render(req, res, "/post", req.params));
+    // APIs
+    const installData = { ...dbResolved, server, $send };
+    robots.install(installData);
+    Object.keys(api).forEach(k => !api[k].doNotInstall && api[k].install(installData));
 
-  // APIs
-  const installData = { ...dbResolved, server, $send };
-  robots.install(installData);
-  Object.keys(api).forEach(k => !api[k].doNotInstall && api[k].install(installData));
+    // Fallback
+    server.get("*", next.getRequestHandler());
+  }).catch(err => console.error("🔥", "Error while preparing server!", err));
+  return server;
+}
 
-  // Fallback
-  server.get('*', next.getRequestHandler());
+const shouldCompress = (req, res) => {
+  if (isDevelopment) return false;
+  if (req.headers["x-no-compression"]) return false;
+  return compression.filter(req, res);
+}
+
+// This installs greenlock, which is used for lets-encrypt.
+const installGreenlock = () => greenlock.create({ ...greenlockOptions(), app: installServer() })
+  .listen(config.port.http, config.port.https, err => err
+    ? console.error("🔥", "Error while listening to greenlock", err)
+    : console.log("📡", `Listening on greenlock ports HTTP ${config.port.http} & HTTPS ${config.port.https}!`));
+
+const greenlockOptions = () => ({
+  agreeTos: true, // todo : You MUST NOT build clients that accept the ToS without asking the user
+  version: "draft-11",
+  server: isDevelopment ? "https://acme-staging-v02.api.letsencrypt.org/directory" : "https://acme-v02.api.letsencrypt.org/directory",
+  email: config.webmasterMail,
+  approveDomains: config.client.domains,
+  configDir: path.resolve(__dirname, "../config"),
+  debug: isDevelopment,
+  communityMember: false,
+  telemetry: false
+});
+
+// This installs spdy, which is used for own certificates.
+const installSpdy = () => {
+  const server = installServer();
 
   // HTTP Server
   if (config.port.http) {
@@ -76,19 +112,15 @@ Promise.all([next.prepare(), db.connected]).then(([_, dbResolved]) => {
   // HTTPS Server
   spdy.createServer(spdyOptions(), server).listen(config.port.https, err => err
     ? console.error("🔥", "Error while listening", err)
-    : console.log("📡", `Listening on port ${config.port.https}!`))
-}).catch(err => console.error("🔥", "Error while preparing server!", err));
-
-const shouldCompress = (req, res) => {
-  if (isDevelopment) return false;
-  if (req.headers["x-no-compression"]) return false;
-  return compression.filter(req, res);
+    : console.log("📡", `Listening on primary HTTPS port ${config.port.https}!`))
 }
 
-const spdyOptions = () => {
-  const { key, cert } = config.certs;
-  return {
-    key: fs.readFileSync(key),
-    cert: fs.readFileSync(cert)
-  };
-};
+const spdyOptions = () => ({
+  key: fs.readFileSync(config.certs.key),
+  cert: fs.readFileSync(config.certs.cert)
+});
+
+const runServer = () => config.certs === "lets-encrypt" ? installGreenlock() : installSpdy();
+
+// Alright, let's rock! 🤘
+runServer();


### PR DESCRIPTION
This is one of the reasons why I honestly love to be a developer.

We AUTOMATICALLY create a SSL certificate for Helios using greenlock(Issued by Let's Encrypt!). The only thing that's required is a valid, public available FQDN and an email address. Works like a breeze on my dev server.

![screenshot_1](https://user-images.githubusercontent.com/7840502/40624749-a9beeb10-62ae-11e8-9c62-3313524adad9.jpg)
