### PR TITLE
No longer save cookies without the users consent

### DIFF
--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -182,14 +182,16 @@ class Form extends React.Component {
       <div className="contol">
         <label className="checkbox">
           <input
+            style={{ marginRight: 2 }}
             type="checkbox"
             ref={this.makeRef(key)}
             disabled={waiting}
             defaultChecked={ignoreData ? false : this.getData(key)} />
-          {this.renderValidationResult(this.getValidationResult(key))}
+          <span>{name}</span>
         </label>
       </div>
-    </div>);
+      {this.renderValidationResult(this.getValidationResult(key))}
+    </div >);
   }
 
   renderValidationResult(result) {

--- a/src/pages/admin/account.js
+++ b/src/pages/admin/account.js
@@ -131,6 +131,12 @@ export default class Account extends React.Component {
           ignoreData: true,
           validator: (pw) => ({ error: !pw, message: "Please enter your password." }),
           placeholder: "Not 123!"
+        },
+        {
+          key: "cookie",
+          type: "checkbox",
+          name: "I agree that this website will use a cookie to keep me signed in.",
+          validator: (cookie) => ({error: !cookie, message: "We cannot sign you in without a cookie. Sorry."})
         }
       ]} />);
   }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -62,8 +62,16 @@ const installServer = () => {
     server.use(express.urlencoded({ limit: config.maxPayloadSize, extended: true }));
     server.use("/static", express.static("static"));
     server.use(session({
-      // todo: Have a look at this again once we switch to HTTPS, or go live(Cookie laws...)!
       // todo: Use a better session store! (MongoDB)
+      name: "helios",
+      cookie: {
+        httpOnly: true,
+        sameSite: true,
+        secure: true // todo: test this with a proxy! -> server.set("trust proxy", 1); to trust 1st proxy
+      },
+      resave: false,
+      saveUninitialized: false,
+      unset: "destroy",
       secret: config.cookieSecret
     }));
 


### PR DESCRIPTION
The laws around cookies and data protection are getting more and more strict. Albeit not required yet, we don't save any cookies AT ALL until the users has explicitly agreed to it by checking a checkbox. (And even that is only required if the user is actually going to sign in)
This should place Helios on the safe side for a very long time.